### PR TITLE
Building an IsolatingClassLoader with multiple parent relationships instead of a single one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ code.
 Loader loader = LoaderBuilder 
     .anIsolatingLoader() 
     .withClasspath(new File("myjar.jar").getUri()) 
-    .withIsolationLevel(IsolationLevel.FULL) 
+    .addParentRelationship(ParentRelationshipBuilder.builder()
+        .withIsolationLevel(IsolationLevel.FULL)
+        .build())
     .build(); 
  
 MyApi myApiImpl = loader.newInstanceOf(MyApi.class, "com.myapi.MyApiImpl"); 
@@ -64,12 +66,14 @@ Classes can also be whitelisted or blacklisted using glob-style patterns, making
 the loaded code:
 
 ```java
-    Loader loader = LoaderBuilder
-        .anIsolatingLoader()
-        .withClasspath(new File("myjar.jar").getUri())
+Loader loader = LoaderBuilder
+    .anIsolatingLoader()
+    .withClasspath(new File("myjar.jar").getUri())
+    .addParentRelationship(ParentRelationshipBuilder.builder() 
         .withIsolationLevel(IsolationLevel.FULL)
         .addWhitelistedClassPattern("com.example.*")
-        .build();
+        .build())
+    .build();
 ```
 
 Building

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolatingLoader.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolatingLoader.java
@@ -18,15 +18,10 @@ import java.util.Set;
  * Isolating loader which delegates most of its work to the IsolatingClassLoader.
  */
 class IsolatingLoader implements Loader {
-  private final IsolationLevel isolationLevel;
-  private final List<URI> classpath;
   private final IsolatingClassLoader classloader;
 
-  IsolatingLoader(List<URI> classpath, OriginRestriction originRestriction, IsolationLevel isolationLevel, Set<GlobMatcher> parentPreferredClassPatterns,
-      Set<GlobMatcher> whitelistedClassPatterns, Set<GlobMatcher> blacklistedClassPatterns) {
-    this.isolationLevel = isolationLevel;
-    this.classpath = classpath;
-
+  IsolatingLoader(List<URI> classpath, OriginRestriction originRestriction,
+      List<ParentRelationship> parentRelationships) {
     URL[] classpathUrls = new URL[classpath.size()];
     for (int i = 0; i < classpathUrls.length; i++) {
       try {
@@ -42,8 +37,7 @@ class IsolatingLoader implements Loader {
       }
     }
 
-    classloader = new IsolatingClassLoader(classpathUrls, getClass().getClassLoader(), isolationLevel,
-        parentPreferredClassPatterns, whitelistedClassPatterns, blacklistedClassPatterns);
+    classloader = new IsolatingClassLoader(classpathUrls, parentRelationships);
   }
 
   @Override

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LoaderBuilder.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LoaderBuilder.java
@@ -9,9 +9,7 @@ package com.linkedin.cytodynamics.nucleus;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 /**
@@ -19,12 +17,9 @@ import java.util.Set;
  * the parent's classloader.
  */
 public final class LoaderBuilder {
-  private IsolationLevel isolationLevel = IsolationLevel.NONE;
-  private List<URI> classpath = new ArrayList<>();
-  private Set<GlobMatcher> parentPreferredClassPatterns = new HashSet<>();
-  private Set<GlobMatcher> blacklistedClassPatterns = new HashSet<>();
-  private Set<GlobMatcher> whitelistedClassPatterns = new HashSet<>();
+  private final List<URI> classpath = new ArrayList<>();
   private OriginRestriction originRestriction = null;
+  private final List<ParentRelationship> parentRelationships = new ArrayList<>();
 
   private LoaderBuilder() {
   }
@@ -36,16 +31,6 @@ public final class LoaderBuilder {
    */
   public static LoaderBuilder anIsolatingLoader() {
     return new LoaderBuilder();
-  }
-
-  /**
-   * Sets the isolation level of the loader. See {@link IsolationLevel} for more details on isolation levels.
-   *
-   * @param isolationLevel The isolation level of the loader.
-   */
-  public LoaderBuilder withIsolationLevel(IsolationLevel isolationLevel) {
-    this.isolationLevel = isolationLevel;
-    return this;
   }
 
   /**
@@ -69,37 +54,8 @@ public final class LoaderBuilder {
     return this;
   }
 
-  /**
-   * Adds a glob pattern for classes to be loaded from the parent classloader as opposed to the child classloader. This
-   * can be used to force the child to use certain classes which must have a common implementation, such as logging
-   * libraries.
-   *
-   * @param pattern A glob pattern for classes to load from the parent classloader, such as "org.apache.log4j.*"
-   */
-  public LoaderBuilder addParentPreferredClassPattern(String pattern) {
-    parentPreferredClassPatterns.add(new GlobMatcher(pattern));
-    return this;
-  }
-
-  /**
-   * Adds a glob pattern for classes never to be loaded from the parent classloader, even if they have an
-   * <code>@Api</code> annotation.
-   *
-   * @param pattern A glob pattern for classes to be avoided from the parent classloader
-   */
-  public LoaderBuilder addBlacklistedClassPattern(String pattern) {
-    blacklistedClassPatterns.add(new GlobMatcher(pattern));
-    return this;
-  }
-
-  /**
-   * Adds a glob pattern for classes to be allowed to be loaded from the parent classloader, if they don't exist in the
-   * child classloader.
-   *
-   * @param pattern A glob pattern for classes to be allowed to be loaded from the parent classloader
-   */
-  public LoaderBuilder addWhitelistedClassPattern(String pattern) {
-    whitelistedClassPatterns.add(new GlobMatcher(pattern));
+  public LoaderBuilder addParentRelationship(ParentRelationship parentRelationship) {
+    this.parentRelationships.add(parentRelationship);
     return this;
   }
 
@@ -113,6 +69,6 @@ public final class LoaderBuilder {
       throw new RuntimeException("No origin restriction set, use OriginRestriction.allowByDefault() if no restriction is desired");
     }
 
-    return new IsolatingLoader(classpath, originRestriction, isolationLevel, parentPreferredClassPatterns, whitelistedClassPatterns, blacklistedClassPatterns);
+    return new IsolatingLoader(classpath, originRestriction, parentRelationships);
   }
 }

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentClassLoaderContext.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentClassLoaderContext.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018-2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.cytodynamics.nucleus;
+
+import java.util.Set;
+
+
+/**
+ * Contains objects and configuration for an individual parent classloading step for {@link IsolatingClassLoader}.
+ */
+public class ParentClassLoaderContext {
+  private final ClassLoader parentClassLoader;
+  private final IsolationLevel isolationLevel;
+  private final Set<GlobMatcher> parentPreferredClassPatterns;
+  private final Set<GlobMatcher> blacklistedClassPatterns;
+  private final Set<GlobMatcher> whitelistedClassPatterns;
+
+  public ParentClassLoaderContext(ClassLoader parent,
+      IsolationLevel isolationLevel,
+      Set<GlobMatcher> parentPreferredClassPatterns,
+      Set<GlobMatcher> blacklistedClassPatterns,
+      Set<GlobMatcher> whitelistedClassPatterns) {
+    this.parentClassLoader = parent;
+    this.isolationLevel = isolationLevel;
+    this.parentPreferredClassPatterns = parentPreferredClassPatterns;
+    this.blacklistedClassPatterns = blacklistedClassPatterns;
+    this.whitelistedClassPatterns = whitelistedClassPatterns;
+  }
+
+  public ClassLoader getParentClassLoader() {
+    return parentClassLoader;
+  }
+
+  public IsolationLevel getIsolationLevel() {
+    return isolationLevel;
+  }
+
+  public Set<GlobMatcher> getParentPreferredClassPatterns() {
+    return parentPreferredClassPatterns;
+  }
+
+  public Set<GlobMatcher> getBlacklistedClassPatterns() {
+    return blacklistedClassPatterns;
+  }
+
+  public Set<GlobMatcher> getWhitelistedClassPatterns() {
+    return whitelistedClassPatterns;
+  }
+}

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationship.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationship.java
@@ -13,14 +13,14 @@ import java.util.Set;
 /**
  * Contains objects and configuration for an individual parent classloading step for {@link IsolatingClassLoader}.
  */
-public class ParentClassLoaderContext {
+public class ParentRelationship {
   private final ClassLoader parentClassLoader;
   private final IsolationLevel isolationLevel;
   private final Set<GlobMatcher> parentPreferredClassPatterns;
   private final Set<GlobMatcher> blacklistedClassPatterns;
   private final Set<GlobMatcher> whitelistedClassPatterns;
 
-  public ParentClassLoaderContext(ClassLoader parent,
+  public ParentRelationship(ClassLoader parent,
       IsolationLevel isolationLevel,
       Set<GlobMatcher> parentPreferredClassPatterns,
       Set<GlobMatcher> blacklistedClassPatterns,

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationship.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationship.java
@@ -20,11 +20,8 @@ public class ParentRelationship {
   private final Set<GlobMatcher> blacklistedClassPatterns;
   private final Set<GlobMatcher> whitelistedClassPatterns;
 
-  public ParentRelationship(ClassLoader parent,
-      IsolationLevel isolationLevel,
-      Set<GlobMatcher> parentPreferredClassPatterns,
-      Set<GlobMatcher> blacklistedClassPatterns,
-      Set<GlobMatcher> whitelistedClassPatterns) {
+  ParentRelationship(ClassLoader parent, IsolationLevel isolationLevel, Set<GlobMatcher> parentPreferredClassPatterns,
+      Set<GlobMatcher> blacklistedClassPatterns, Set<GlobMatcher> whitelistedClassPatterns) {
     this.parentClassLoader = parent;
     this.isolationLevel = isolationLevel;
     this.parentPreferredClassPatterns = parentPreferredClassPatterns;

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationshipBuilder.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ParentRelationshipBuilder.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2018-2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.cytodynamics.nucleus;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * Loader builder fluent interface, used to build loaders with a given classpath and a specific level of isolation from
+ * the parent's classloader.
+ */
+public final class ParentRelationshipBuilder {
+  private ClassLoader parentClassLoader = getClass().getClassLoader();
+  private IsolationLevel isolationLevel = IsolationLevel.NONE;
+  private Set<GlobMatcher> parentPreferredClassPatterns = new HashSet<>();
+  private Set<GlobMatcher> blacklistedClassPatterns = new HashSet<>();
+  private Set<GlobMatcher> whitelistedClassPatterns = new HashSet<>();
+
+  private ParentRelationshipBuilder() {
+  }
+
+  /**
+   * Creates a blank {@link ParentRelationshipBuilder}
+   *
+   * @return A new {@link ParentRelationshipBuilder}
+   */
+  public static ParentRelationshipBuilder builder() {
+    return new ParentRelationshipBuilder();
+  }
+
+  /**
+   * Sets the parent classloader for this parent relationship. By default, this is the classloader which loaded the
+   * {@link ParentRelationshipBuilder} class.
+   *
+   * @param parentClassLoader parent classloader for the parent relationship
+   */
+  public ParentRelationshipBuilder withParentClassLoader(ClassLoader parentClassLoader) {
+    this.parentClassLoader = parentClassLoader;
+    return this;
+  }
+
+  /**
+   * Sets the isolation level of the parent relationship. See {@link IsolationLevel} for more details on isolation
+   * levels.
+   *
+   * @param isolationLevel The isolation level of the parent relationship.
+   */
+  public ParentRelationshipBuilder withIsolationLevel(IsolationLevel isolationLevel) {
+    this.isolationLevel = isolationLevel;
+    return this;
+  }
+
+  /**
+   * Adds a glob pattern for classes to be loaded from the parent classloader as opposed to the child classloader. This
+   * can be used to force the child to use certain classes which must have a common implementation, such as logging
+   * libraries.
+   *
+   * @param pattern A glob pattern for classes to load from the parent classloader, such as "org.apache.log4j.*"
+   */
+  public ParentRelationshipBuilder addParentPreferredClassPattern(String pattern) {
+    this.parentPreferredClassPatterns.add(new GlobMatcher(pattern));
+    return this;
+  }
+
+  /**
+   * Adds a glob pattern for classes never to be loaded from the parent classloader, even if they have an
+   * <code>@Api</code> annotation.
+   *
+   * @param pattern A glob pattern for classes to be avoided from the parent classloader
+   */
+  public ParentRelationshipBuilder addBlacklistedClassPattern(String pattern) {
+    this.blacklistedClassPatterns.add(new GlobMatcher(pattern));
+    return this;
+  }
+
+  /**
+   * Adds a glob pattern for classes to be allowed to be loaded from the parent classloader, if they don't exist in the
+   * child classloader.
+   *
+   * @param pattern A glob pattern for classes to be allowed to be loaded from the parent classloader
+   */
+  public ParentRelationshipBuilder addWhitelistedClassPattern(String pattern) {
+    this.whitelistedClassPatterns.add(new GlobMatcher(pattern));
+    return this;
+  }
+
+  /**
+   * Builds an instance of a {@link ParentRelationship} with the given parameters.
+   *
+   * @return A {@link ParentRelationship} with the given parameters.
+   */
+  public ParentRelationship build() {
+    return new ParentRelationship(this.parentClassLoader, this.isolationLevel, this.parentPreferredClassPatterns,
+        this.blacklistedClassPatterns, this.whitelistedClassPatterns);
+  }
+}

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
@@ -60,10 +60,12 @@ public class OriginRestrictionTest {
     // Shouldn't be able to load a class through a redirect
     Loader loader = LoaderBuilder
         .anIsolatingLoader()
-        .withIsolationLevel(IsolationLevel.FULL)
-        .withOriginRestriction(allowOnlyLocalhost)
-        .addWhitelistedClassPattern("java.*")
         .withClasspath(Collections.singletonList(new URI(ALLOWED_JAR_LOCATION)))
+        .withOriginRestriction(allowOnlyLocalhost)
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .build())
         .build();
 
     Class clazz = loader.loadClass(Object.class, "org.apache.log4j.Logger");
@@ -72,10 +74,12 @@ public class OriginRestrictionTest {
     // Should be able to load the class using the original URL
     loader = LoaderBuilder
         .anIsolatingLoader()
-        .withIsolationLevel(IsolationLevel.FULL)
-        .withOriginRestriction(OriginRestriction.allowByDefault())
-        .addWhitelistedClassPattern("java.*")
         .withClasspath(Collections.singletonList(new URI(REDIRECTED_JAR_LOCATION)))
+        .withOriginRestriction(OriginRestriction.allowByDefault())
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .build())
         .build();
 
     clazz = loader.loadClass(Object.class, "org.apache.log4j.Logger");

--- a/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceAOnlyImpl.java
+++ b/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceAOnlyImpl.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018-2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.cytodynamics.test;
+
+/**
+ * Class which is only in cytodynamics-test-a.
+ */
+public class TestInterfaceAOnlyImpl implements TestInterface {
+  @Override
+  public String getValue() {
+    return "A-only";
+  }
+
+  @Override
+  public boolean classExists(String className) {
+    try {
+      Class.forName(className);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
@@ -13,11 +13,15 @@ import com.linkedin.cytodynamics.nucleus.LoaderBuilder;
 import com.linkedin.cytodynamics.nucleus.OriginRestriction;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import com.linkedin.cytodynamics.nucleus.ParentRelationshipBuilder;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -98,9 +102,11 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -113,9 +119,11 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("b")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -128,9 +136,11 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -145,9 +155,11 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.lang.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.lang.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -158,7 +170,9 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.TRANSITIONAL)
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.TRANSITIONAL)
+            .build())
         .build();
 
     implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -169,7 +183,9 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.NONE)
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.NONE)
+            .build())
         .build();
 
     implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -183,10 +199,12 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addBlacklistedClassPattern("java.util.Set")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addBlacklistedClassPattern("java.util.Set")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -197,8 +215,10 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.TRANSITIONAL)
-        .addBlacklistedClassPattern("java.util.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.TRANSITIONAL)
+            .addBlacklistedClassPattern("java.util.*")
+            .build())
         .build();
 
     implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -209,8 +229,10 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.NONE)
-        .addBlacklistedClassPattern("java.util.Set")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.NONE)
+            .addBlacklistedClassPattern("java.util.Set")
+            .build())
         .build();
 
     implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -224,18 +246,22 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("a")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     Loader loaderB = LoaderBuilder
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri("b")))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementationA = loaderA.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -243,6 +269,62 @@ public class TestDynamicLoad {
 
     assertEquals(implementationA.getValue(), "A");
     assertEquals(implementationB.getValue(), "B");
+  }
+
+  @Test(description = "Given that there are multiple parent relationships, and all can load a class, the class should "
+      + "be loaded from the first parent relationship")
+  public void testMultipleParentsLoadFromFirstParent() throws MalformedURLException {
+    URL testApiJarURL = getTestJarUri("api").toURL();
+    ClassLoader parentClassLoaderA = new URLClassLoader(new URL[]{testApiJarURL, getTestJarUri("a").toURL()}, null);
+    ClassLoader parentClassLoaderB = new URLClassLoader(new URL[]{testApiJarURL, getTestJarUri("b").toURL()}, null);
+    Loader loader = LoaderBuilder
+        .anIsolatingLoader()
+        .withOriginRestriction(OriginRestriction.allowByDefault())
+        // will load class from parent, so don't need any classpath
+        .withClasspath(Collections.emptyList())
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withParentClassLoader(parentClassLoaderA)
+            // using NONE so that we can load the class from the parent
+            .withIsolationLevel(IsolationLevel.NONE)
+            .addWhitelistedClassPattern("java.*")
+            .build())
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withParentClassLoader(parentClassLoaderB)
+            // using NONE so that we can load the class from the parent
+            .withIsolationLevel(IsolationLevel.NONE)
+            .addWhitelistedClassPattern("java.*")
+            .build())
+        .build();
+    Class<?> clazz = loader.loadClass(Object.class, TestInterfaceImpl.class.getName());
+    assertEquals(clazz.getClassLoader(), parentClassLoaderA);
+  }
+
+  @Test(description = "Given that there are multiple parent relationships, but only the last parent has a class, the "
+      + "class should be loaded by the last parent")
+  public void testMultipleParentsLoadFromLastParent() throws MalformedURLException {
+    URL testApiJarURL = getTestJarUri("api").toURL();
+    ClassLoader parentClassLoaderA = new URLClassLoader(new URL[]{testApiJarURL, getTestJarUri("a").toURL()}, null);
+    ClassLoader parentClassLoaderB = new URLClassLoader(new URL[]{testApiJarURL, getTestJarUri("b").toURL()}, null);
+    Loader loader = LoaderBuilder
+        .anIsolatingLoader()
+        .withOriginRestriction(OriginRestriction.allowByDefault())
+        // will load class from parent, so don't need any classpath
+        .withClasspath(Collections.emptyList())
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withParentClassLoader(parentClassLoaderA)
+            // using FULL so that the implementation class is not loaded from this parent
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .build())
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withParentClassLoader(parentClassLoaderB)
+            // using NONE so that we can load the class from the parent
+            .withIsolationLevel(IsolationLevel.NONE)
+            .addWhitelistedClassPattern("java.*")
+            .build())
+        .build();
+    Class<?> clazz = loader.loadClass(Object.class, TestInterfaceImpl.class.getName());
+    assertEquals(clazz.getClassLoader(), parentClassLoaderB);
   }
 
   @Test
@@ -262,10 +344,12 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(OriginRestriction.allowByDefault())
         .withClasspath(Collections.singletonList(getTestJarUri(jarToUse)))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
-        .addParentPreferredClassPattern("com.linkedin.cytodynamics.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .addParentPreferredClassPattern("com.linkedin.cytodynamics.*")
+            .build())
         .build();
 
     TestInterface childImplementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -283,8 +367,10 @@ public class TestDynamicLoad {
           .anIsolatingLoader()
           .withOriginRestriction(OriginRestriction.allowByDefault())
           .withClasspath(Collections.singletonList(getTestJarUri("a")))
-          .withIsolationLevel(IsolationLevel.FULL)
-          .addWhitelistedClassPattern("java.*")
+          .addParentRelationship(ParentRelationshipBuilder.builder()
+              .withIsolationLevel(IsolationLevel.FULL)
+              .addWhitelistedClassPattern("java.*")
+              .build())
           .build();
 
       TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -318,8 +404,10 @@ public class TestDynamicLoad {
           .anIsolatingLoader()
           .withOriginRestriction(onlyTmpOriginRestriction)
           .withClasspath(Collections.singletonList(getTestJarUri("a")))
-          .withIsolationLevel(IsolationLevel.FULL)
-          .addWhitelistedClassPattern("java.*")
+          .addParentRelationship(ParentRelationshipBuilder.builder()
+              .withIsolationLevel(IsolationLevel.FULL)
+              .addWhitelistedClassPattern("java.*")
+              .build())
           .build();
 
       TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());
@@ -333,9 +421,11 @@ public class TestDynamicLoad {
         .anIsolatingLoader()
         .withOriginRestriction(onlyTmpOriginRestriction)
         .withClasspath(Collections.singletonList(destinationFile.toURI()))
-        .withIsolationLevel(IsolationLevel.FULL)
-        .addWhitelistedClassPattern("java.*")
-        .addWhitelistedClassPattern("com.intellij.*")
+        .addParentRelationship(ParentRelationshipBuilder.builder()
+            .withIsolationLevel(IsolationLevel.FULL)
+            .addWhitelistedClassPattern("java.*")
+            .addWhitelistedClassPattern("com.intellij.*")
+            .build())
         .build();
 
     TestInterface implementation = loader.newInstanceOf(TestInterface.class, TestInterfaceImpl.class.getName());

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
@@ -289,13 +289,11 @@ public class TestDynamicLoad {
             .withParentClassLoader(parentClassLoaderA)
             // using NONE so that we can load the class from the parent
             .withIsolationLevel(IsolationLevel.NONE)
-            .addWhitelistedClassPattern("java.*")
+            .addParentPreferredClassPattern("java.*")
             .build())
         .addParentRelationship(ParentRelationshipBuilder.builder()
             .withParentClassLoader(parentClassLoaderB)
-            // using NONE so that we can load the class from the parent
             .withIsolationLevel(IsolationLevel.NONE)
-            .addWhitelistedClassPattern("java.*")
             .build())
         .build();
     Class<?> clazz = loader.loadClass(Object.class, TestInterfaceImpl.class.getName());
@@ -317,13 +315,12 @@ public class TestDynamicLoad {
             .withParentClassLoader(parentClassLoaderA)
             // using FULL so that the implementation class is not loaded from this parent
             .withIsolationLevel(IsolationLevel.FULL)
-            .addWhitelistedClassPattern("java.*")
+            .addParentPreferredClassPattern("java.*")
             .build())
         .addParentRelationship(ParentRelationshipBuilder.builder()
             .withParentClassLoader(parentClassLoaderB)
             // using NONE so that we can load the class from the parent
             .withIsolationLevel(IsolationLevel.NONE)
-            .addWhitelistedClassPattern("java.*")
             .build())
         .build();
     Class<?> clazz = loader.loadClass(Object.class, TestInterfaceImpl.class.getName());
@@ -363,13 +360,11 @@ public class TestDynamicLoad {
         .addParentRelationship(ParentRelationshipBuilder.builder()
             .withParentClassLoader(commonParent)
             .withIsolationLevel(IsolationLevel.FULL)
-            .addWhitelistedClassPattern("java.*")
-            .addWhitelistedClassPattern(TestInterface.class.getName())
+            .addParentPreferredClassPattern("java.*")
             .build())
         .addParentRelationship(ParentRelationshipBuilder.builder()
             .withParentClassLoader(partialDelegation)
             .withIsolationLevel(IsolationLevel.NONE)
-            .addWhitelistedClassPattern("java.*")
             .build())
         .build();
 

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
@@ -361,6 +361,8 @@ public class TestDynamicLoad {
             .withParentClassLoader(commonParent)
             .withIsolationLevel(IsolationLevel.FULL)
             .addParentPreferredClassPattern("java.*")
+            // TODO fix: when loader's classloader doesn't match the parent classloader, Api annotation doesn't apply
+            .addParentPreferredClassPattern(TestInterface.class.getName())
             .build())
         .addParentRelationship(ParentRelationshipBuilder.builder()
             .withParentClassLoader(partialDelegation)


### PR DESCRIPTION
This PR adds a way to specify multiple parent relationships when building an `IsolatingClassLoader`.

This allows for the following case:
1) Infrastructure classes are under one classloader, and they need to be isolated from a user classpath
2) User classpath needs to delegate to the infrastructure classloader for API classes
3) Some infrastructure classes should be able to delegate to the user classpath for certain reflection cases

Concrete example:
1) Samza infrastructure classpath needs to be isolated from user classpath to avoid dependency conflicts
2) User classpath needs to implement certain Samza interfaces (e.g. `SamzaApplication`) in order to execute the application
3) Samza consumer needs to be able to access schema classes (e.g. Avro schemas) on the user classpath in order to pass objects of the schema type(s) to the user code (schema classes are loaded through reflection)

By having multiple parent relationships, we can avoid a circular delegation using 3 classloaders:
1) Contains the Samza API classes
2) Contains the Samza consumer implementation
3) Contains the user classpath

The main classloader will have 2 parent relationships: (1) is a parent of (2) with `IsolationLevel.FULL`, (3) is a parent of (2) with `IsolationLevel.NONE`. This allows (2) to delegate to (1) for API classes, and it allows (2) to delegate to (3) for schemas.
(3) will also be an `IsolatingClassLoader` with a single parent which is (1), with `IsolationLevel.FULL`. This allows (3) to delegate to (1) for API classes.