### PR TITLE
Revert "Remove blurb about HTTP redirects"

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,7 +19,3 @@ License: Apache 2.0
 This product includes/uses JCommander (https://jcommander.org/)
 Copyright 2012 Cédric Beust
 License: Apache 2.0
-
-This product includes/uses the Spark Framework (http://sparkjava.com/)
-Copyright 2011- Per Wendel
-License: Apache 2.0

--- a/cytodynamics-nucleus/pom.xml
+++ b/cytodynamics-nucleus/pom.xml
@@ -45,12 +45,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sparkjava</groupId>
-      <artifactId>spark-core</artifactId>
-      <version>2.7.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.21</version>

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestriction.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestriction.java
@@ -17,6 +17,13 @@ import java.util.List;
 
 /**
  * Origin restriction, which allows restricting the origin of JARs present in the classpath.
+ *
+ * This is used to filter the original URL on the classpath, but does not take into account redirects. For example, if
+ * the URL filter allows http://myhost.com/myjar.jar and that server redirects to http://malicious.com/evil.jar, then
+ * the URL filter allows it.
+ *
+ * For finer control on the JARs loaded, we recommend denying by default and only allowing JARs downloaded at an
+ * application-controlled location.
  */
 public class OriginRestriction {
   private final boolean allowedByDefault;

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
@@ -7,13 +7,11 @@
  */
 package com.linkedin.cytodynamics.nucleus;
 
-import java.net.URI;
 import java.net.URL;
-import java.util.Collections;
 import org.testng.annotations.Test;
-import spark.Spark;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class OriginRestrictionTest {
@@ -40,56 +38,5 @@ public class OriginRestrictionTest {
     assertFalse(denyHttpAllowDefault.isAllowed(new URL("http://foo/")));
     assertTrue(denyHttpAllowDefault.isAllowed(new URL("https://foo/")));
     assertTrue(denyHttpAllowDefault.isAllowed(new URL("file:///foo")));
-  }
-
-  @Test
-  public void testFailRedirect() throws Exception {
-    final String ALLOWED_JAR_LOCATION = "http://localhost:4567/test.jar";
-    final String REDIRECTED_JAR_LOCATION = "http://central.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar";
-
-    // Start HTTP server that redirects to another host
-    Spark.get("/test.jar", (request, response) -> {
-      response.redirect(REDIRECTED_JAR_LOCATION);
-      return "";
-    });
-
-    OriginRestriction allowOnlyLocalhost = OriginRestriction
-        .denyByDefault()
-        .allowingGlobPattern(ALLOWED_JAR_LOCATION);
-
-    // Shouldn't be able to load a class through a redirect
-    ClassLoader loader = LoaderBuilder
-        .anIsolatingLoader()
-        .withClasspath(Collections.singletonList(new URI(ALLOWED_JAR_LOCATION)))
-        .withOriginRestriction(allowOnlyLocalhost)
-        .withParentRelationship(DelegateRelationshipBuilder.builder()
-            .withIsolationLevel(IsolationLevel.FULL)
-            .addWhitelistedClassPattern("java.*")
-            .build())
-        .build();
-
-    try {
-      loader.loadClass("org.apache.log4j.Logger");
-      fail("Expected to get a ClassNotFoundException, since it is not allowed to ");
-    } catch (ClassNotFoundException e) {
-      // expected to reach here
-    }
-
-    // Should be able to load the class using the original URL
-    loader = LoaderBuilder
-        .anIsolatingLoader()
-        .withClasspath(Collections.singletonList(new URI(REDIRECTED_JAR_LOCATION)))
-        .withOriginRestriction(OriginRestriction.allowByDefault())
-        .withParentRelationship(DelegateRelationshipBuilder.builder()
-            .withIsolationLevel(IsolationLevel.FULL)
-            .addWhitelistedClassPattern("java.*")
-            .build())
-        .build();
-
-    Class<?> clazz = loader.loadClass("org.apache.log4j.Logger");
-    assertNotNull(clazz);
-
-    // Stop HTTP server
-    Spark.stop();
   }
 }


### PR DESCRIPTION
This reverts commit c9df87ff9482e6cbfac971b2355950111c86c1d6.

Reasoning for revert:
The description of the reverted commit stated that HTTP redirects are
not followed by URLClassLoader, but it looks like they in fact are
followed.
The test that was added by the reverted commit was not properly implemented,
since the fake HTTP endpoint was not initialized properly. Therefore, the
fake HTTP redirect never got triggered. The test succeeded because nothing
got loaded from the fake non-redirect URL, so the class wasn't found. When
the fake HTTP endpoint was properly initialized using Spark.awaitInitialization,
then the redirect was triggered, and the class did get loaded.