### PR TITLE
cleaning up IDE warnings: remove double-star from license comment, remove unused variables

### DIFF
--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/CytodynamicsClassNotFoundException.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/CytodynamicsClassNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/InvalidBuilderParametersException.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/InvalidBuilderParametersException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/OriginValidationException.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/exception/OriginValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/Chooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/Chooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/ChooserMappingFactory.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/ChooserMappingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/FullIsolationChooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/FullIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/NoneIsolationChooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/NoneIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/NoneIsolationListChooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/NoneIsolationListChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/TransitionalIsolationChooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/TransitionalIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/TransitionalIsolationListChooser.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/isolation/TransitionalIsolationListChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/matcher/BootstrapClassPredicate.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/matcher/BootstrapClassPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/matcher/GlobMatcher.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/matcher/GlobMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Api.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Api.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/BaseOriginRestrictionFilter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/BaseOriginRestrictionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/DelegateRelationship.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/DelegateRelationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/DelegateRelationshipBuilder.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/DelegateRelationshipBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/FileOriginRestrictionFilter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/FileOriginRestrictionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/GlobPatternRestrictionFilter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/GlobPatternRestrictionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolatingClassLoader.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolatingClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolationLevel.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/IsolationLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/JulLogAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/JulLogAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LoaderBuilder.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LoaderBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Log4j1LogAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Log4j1LogAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *
@@ -16,7 +16,7 @@ import org.apache.log4j.LogManager;
 class Log4j1LogAdapter implements LogAdapter {
   static boolean isAvailable() {
     try {
-      Class<?> ignored = Class.forName("org.apache.log4j.Logger");
+      Class.forName("org.apache.log4j.Logger");
       return true;
     } catch (ClassNotFoundException e) {
       return false;

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Log4j2LogAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Log4j2LogAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.LogManager;
 class Log4j2LogAdapter implements LogAdapter {
   static boolean isAvailable() {
     try {
-      Class<?> ignored = Class.forName("org.apache.logging.log4j.Logger");
+      Class.forName("org.apache.logging.log4j.Logger");
       return true;
     } catch (ClassNotFoundException e) {
       return false;

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LogAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LogAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LogApiAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/LogApiAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Logger.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginMatchResults.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginMatchResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestriction.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionFilter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ProtocolOriginRestrictionFilter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/ProtocolOriginRestrictionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/SLF4jLogAdapter.java
+++ b/cytodynamics-nucleus/src/main/java/com/linkedin/cytodynamics/nucleus/SLF4jLogAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 class SLF4jLogAdapter implements LogAdapter {
   static boolean isAvailable() {
     try {
-      Class<?> ignored = Class.forName("org.slf4j.Logger");
+      Class.forName("org.slf4j.Logger");
       return true;
     } catch (ClassNotFoundException e) {
       return false;

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestChooserMappingFactory.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestChooserMappingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestFullIsolationChooser.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestFullIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestNoneIsolationChooser.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestNoneIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestNoneIsolationListChooser.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestNoneIsolationListChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestTransitionalIsolationChooser.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestTransitionalIsolationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestTransitionalIsolationListChooser.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/isolation/TestTransitionalIsolationListChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/matcher/BootstrapClassPredicateTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/matcher/BootstrapClassPredicateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/matcher/GlobMatcherTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/matcher/GlobMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/FileOriginRestrictionFilterTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/FileOriginRestrictionFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/GlobPatternRestrictionFilterTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/GlobPatternRestrictionFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/OriginRestrictionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/ProtocolOriginRestrictionFilterTest.java
+++ b/cytodynamics-nucleus/src/test/java/com/linkedin/cytodynamics/nucleus/ProtocolOriginRestrictionFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceAOnlyImpl.java
+++ b/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceAOnlyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceImpl.java
+++ b/cytodynamics-test-a/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-api/src/main/java/com/linkedin/cytodynamics/test/NonApiTestInterface.java
+++ b/cytodynamics-test-api/src/main/java/com/linkedin/cytodynamics/test/NonApiTestInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-api/src/main/java/com/linkedin/cytodynamics/test/TestInterface.java
+++ b/cytodynamics-test-api/src/main/java/com/linkedin/cytodynamics/test/TestInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-b/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceImpl.java
+++ b/cytodynamics-test-b/src/main/java/com/linkedin/cytodynamics/test/TestInterfaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/nucleus/TestLoadClassResolve.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/nucleus/TestLoadClassResolve.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/test/TestDynamicLoad.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/util/JarUtil.java
+++ b/cytodynamics-test-container/src/test/java/com/linkedin/cytodynamics/util/JarUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018-2019 LinkedIn Corporation
  * All Rights Reserved.
  *

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,9 @@
             <owner>LinkedIn Corporation</owner>
             <email>cytodynamics@linkedin.com</email>
           </properties>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
           <excludes>
             <exclude>**/README</exclude>
             <exclude>**/*.md</exclude>


### PR DESCRIPTION
The IDE warns that `/**` is a "dangling javadoc comment" when at the top of the file. This is the pattern that com.mycila:license-maven-plugin uses for Java files by default, but it should be using `/*` (https://github.com/mycila/license-maven-plugin/issues/118).